### PR TITLE
[Issues/#11]Pull requestのアクションをslackに通知する

### DIFF
--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -11,7 +11,7 @@ module.exports = (robot) ->
 #      when 'pull_request_comment'
 #        message = postPullRequestComment data
 
-    robot.send {room: "#issues"}, message
+    robot.send {room: "#pullrequests"}, message
     res.end ""
 
   postPullRequest = (data) ->

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -6,10 +6,10 @@ module.exports = (robot) ->
     switch event_type
       when 'pull_request'
         message = postPullRequest data
-      when 'pull_request_review'
-        message = postPullRequestReview data
       when 'pull_request_review_comment'
         message = postPullRequestReviewComment data
+      else
+        message = ""
 
     robot.send {room: "#pullrequests"}, message
     res.end ""
@@ -31,6 +31,9 @@ module.exports = (robot) ->
       when 'review_request_removed'
         slackUser = eval("process.env.#{reviewer.login}")
         message = "@#{slackUser} <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}>のレビューが取り消されました"
+      else
+        message = ""
+
     return message
 
   postPullRequestReviewComment = (data) ->
@@ -43,7 +46,6 @@ module.exports = (robot) ->
         targetSlackUser = eval("process.env.#{assignee.login}")
         sourceSlackUser = eval("process.env.#{comment.user.login}")
         message = "@#{targetSlackUser} #{comment.body} in <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}> by #{sourceSlackUser}"
+      else
+        message = ""
     return message
-
-  postPullRequestReview = (data) ->
-    return data.action

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -1,0 +1,29 @@
+module.exports = (robot) ->
+  robot.router.post '/github/webhook/pullrequests', (req, res) ->
+    event_type = req.get 'X-Github-Event'
+    data = req.body
+
+    switch event_type
+      when 'pull_request'
+        message = postPullRequest data
+#      when 'pull_request_review'
+#        message = postPullRequestReview data
+#      when 'pull_request_comment'
+#        message = postPullRequestComment data
+
+    robot.send {room: "#issues"}, message
+    res.end ""
+
+  postPullRequest = (data) ->
+    action = data.action
+    switch action
+      when 'opened'
+        message = "opened"
+      when 'closed'
+        message = "closed"
+      when 'review_requested'
+        message = "review_requested"
+      when 'review_request_removed'
+        message = "review_request_removed"
+    return message
+

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -6,10 +6,10 @@ module.exports = (robot) ->
     switch event_type
       when 'pull_request'
         message = postPullRequest data
-#      when 'pull_request_review'
-#        message = postPullRequestReview data
-#      when 'pull_request_comment'
-#        message = postPullRequestComment data
+      when 'pull_request_review'
+        message = postPullRequestReview data
+      when 'pull_request_comment'
+        message = postPullRequestComment data
 
     robot.send {room: "#pullrequests"}, message
     res.end ""
@@ -33,3 +33,14 @@ module.exports = (robot) ->
         message = "@#{slackUser} <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}>のレビューが取り消されました"
     return message
 
+  postPullRequestComment = (data) ->
+    action = data.action
+    comment = data.comment
+    pullRequest = data.pull_request
+    assignee = pullRequest.assignee
+    switch action
+      when 'created'
+        targetSlackUser = eval("process.env.#{assignee.login}")
+        sourceSlackUser = eval("process.env.#{comment.user.login}")
+        message = "@#{targetSlackUser} #{comment.body} in <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}> by #{sourceSlackUser}"
+    return message

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -16,14 +16,20 @@ module.exports = (robot) ->
 
   postPullRequest = (data) ->
     action = data.action
+    pullRequest = data.pull_request
+    reviewer = data.requested_reviewer
     switch action
       when 'opened'
-        message = "opened"
+        slackUser = eval("process.env.#{pullRequest.user.login}")
+        message = "#{slackUser}さんが <#{pullRequest.html_url}|#{pullRequest.title} \##{pullRequest.number}>を作成しました"
       when 'closed'
-        message = "closed"
+        slackUser = eval("process.env.#{pullRequest.user.login}")
+        message = "#{slackUser}さんが <#{pullRequest.html_url}|#{pullRequest.title} \##{pullRequest.number}>を終了しました"
       when 'review_requested'
-        message = "review_requested"
+        slackUser = eval("process.env.#{reviewer.login}")
+        message = "@#{slackUser} <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}>のレビューを依頼されました"
       when 'review_request_removed'
-        message = "review_request_removed"
+        slackUser = eval("process.env.#{reviewer.login}")
+        message = "@#{slackUser} <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}>のレビューが取り消されました"
     return message
 

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -44,3 +44,6 @@ module.exports = (robot) ->
         sourceSlackUser = eval("process.env.#{comment.user.login}")
         message = "@#{targetSlackUser} #{comment.body} in <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}> by #{sourceSlackUser}"
     return message
+
+  postPullRequestReview = (data) ->
+    return data.action

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -8,8 +8,8 @@ module.exports = (robot) ->
         message = postPullRequest data
       when 'pull_request_review'
         message = postPullRequestReview data
-      when 'pull_request_comment'
-        message = postPullRequestComment data
+      when 'pull_request_review_comment'
+        message = postPullRequestReviewComment data
 
     robot.send {room: "#pullrequests"}, message
     res.end ""
@@ -33,7 +33,7 @@ module.exports = (robot) ->
         message = "@#{slackUser} <#{pullRequest.html_url}|#{pullRequest.title} ##{pullRequest.number}>のレビューが取り消されました"
     return message
 
-  postPullRequestComment = (data) ->
+  postPullRequestReviewComment = (data) ->
     action = data.action
     comment = data.comment
     pullRequest = data.pull_request


### PR DESCRIPTION
## 概要
Pull Requestのアクションを検知し、通知
対象アクション
* レビュアーを選ぶ
* レビューコメント
* Pull requestの作成/削除

## 検証
### Reviewerを選定
`ryo2851`を選定
<img width="276" alt="2017-08-14 1 19 43" src="https://user-images.githubusercontent.com/12455284/29251381-acea95c6-808e-11e7-825e-656a54876825.png">

### レビューコメント
#15 にコメントをした。
<img width="336" alt="2017-08-14 1 18 03" src="https://user-images.githubusercontent.com/12455284/29251356-73a1adfe-808e-11e7-9aa4-ce63bd1235e9.png">

### 作成
このPRを立てたときの通知
<img width="289" alt="2017-08-14 1 18 49" src="https://user-images.githubusercontent.com/12455284/29251370-9c069b74-808e-11e7-81d7-d65079917dd4.png">

