### PR TITLE
[issues/#38]ハイフンつきのgithubユーザ名に対応

### DIFF
--- a/scripts/issues_notification.coffee
+++ b/scripts/issues_notification.coffee
@@ -1,3 +1,5 @@
+parsedUser = require('./user_parser').parsedUser
+
 module.exports = (robot) ->
   robot.router.post '/github/webhook/issues', (req, res) ->
     event_type = req.get 'X-Github-Event'
@@ -16,7 +18,8 @@ module.exports = (robot) ->
     action = data.action
     issue = data.issue
     assignee = data.issue.assignee
-    slackUser = eval("process.env.#{issue.user.login}")
+    slackUser = eval("process.env.#{parsedUser issue.user.login}")
+    console.log "replace: #{slackUser}"
     color=""
     word=""
     switch action
@@ -30,11 +33,11 @@ module.exports = (robot) ->
         color = "#96ffdc"
         word = "を再開しました"
       when 'assigned'
-        slackUser = eval("process.env.#{assignee.login}")
+        slackUser = eval("process.env.#{parsedUser assignee.login}")
         color = "#0000ff"
         word = "の担当になりました"
       when 'unassigned'
-        slackUser = eval("process.env.#{assignee.login}")
+        slackUser = eval("process.env.#{parsedUser assignee.login}")
         color = "#d2d2d3"
         word ="の担当ではなくなりました"
       else
@@ -46,8 +49,8 @@ module.exports = (robot) ->
     action = data.action
     issue_comment = data.comment
     assignee = data.issue.assignee
-    targetSlackUser = eval("process.env.#{assignee.login}")
-    sourceSlackUser = eval("process.env.#{issue_comment.user.login}")
+    targetSlackUser = eval("process.env.#{parsedUser assignee.login}")
+    sourceSlackUser = eval("process.env.#{parsedUser issue_comment.user.login}")
     switch action
       when 'created'
         if targetSlackUser != sourceSlackUser
@@ -63,12 +66,12 @@ module.exports = (robot) ->
   makeAttachments = (data, slackUser, color, word, type) ->
     assigneeList = []
     for assigneeBody in data.issue.assignees
-      assignee = eval("process.env.#{assigneeBody.login}")
+      assignee = eval("process.env.#{parsedUser assigneeBody.login}")
       assignee = "@#{assignee}"
       assigneeList.push(assignee)
     assigneeStrForNotification = assigneeList.join ', '
     assigneeStrForDisplay = assigneeList.join '\n'
-    register = eval("process.env.#{data.sender.login}")
+    register = eval("process.env.#{parsedUser data.sender.login}")
     pretext = ""
     text = ""
     if type is 'issue'

--- a/scripts/projects_notification.coffee
+++ b/scripts/projects_notification.coffee
@@ -1,3 +1,5 @@
+parsedUser = require('./user_parser').parsedUser
+
 module.exports = (robot) ->
   robot.router.post '/github/webhook/projects', (req, res) ->
 
@@ -14,10 +16,9 @@ module.exports = (robot) ->
   prepareForNotificationOfProjectCard = (data) ->
     action = data.action
     sender = data.sender
-    console.log(process.env)
     cmd = ""
-    if eval("process.env.#{sender.login}")?
-      cmd = "process.env.#{sender.login}"
+    if eval("process.env.#{parsedUser sender.login}")?
+      cmd = "process.env.#{parsedUser sender.login}"
     login_name = eval(cmd)
     switch action
       when 'created', 'deleted'

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -1,3 +1,5 @@
+parsedUser = require('./user_parser').parsedUser
+
 module.exports = (robot) ->
   robot.router.post '/github/webhook/pullrequests', (req, res) ->
     event_type = req.get 'X-Github-Event'
@@ -19,23 +21,22 @@ module.exports = (robot) ->
     reviewer = data.requested_reviewer
     switch action
       when 'opened'
-        slackUser = eval("process.env.#{pullRequest.user.login}")
+        slackUser = eval("process.env.#{parsedUser pullRequest.user.login}")
         color = "#c8ff00"
         word = "を作成しました"
-        message = "#{slackUser}さんが <#{pullRequest.html_url}|#{pullRequest.title} \##{pullRequest.number}>を作成しました"
         makeAttachments data, slackUser, color, word, "pull_request"
       when 'closed'
-        slackUser = eval("process.env.#{pullRequest.user.login}")
+        slackUser = eval("process.env.#{parsedUser pullRequest.user.login}")
         color = "#dc4000"
         word = "をクローズしました"
         makeAttachments data, slackUser, color, word, "pull_request"
       when 'review_requested'
-        slackUser = eval("process.env.#{reviewer.login}")
+        slackUser = eval("process.env.#{parsedUser reviewer.login}")
         color = "#0000ff"
         word = "にレビュー依頼があります"
         makeAttachments data, slackUser, color, word, "review_request"
       when 'review_request_removed'
-        slackUser = eval("process.env.#{reviewer.login}")
+        slackUser = eval("process.env.#{parsedUser reviewer.login}")
         color = "#d2d2d3"
         word = "へのレビュー依頼が取り消されました"
         makeAttachments data, slackUser, color, word, "review_request"
@@ -51,7 +52,6 @@ module.exports = (robot) ->
     switch action
       when 'submitted'
         targetSlackUser = eval("process.env.#{assignee.login}")
-        sourceSlackUser = eval("process.env.#{comment.user.login}")
         color = "#34adc6"
         word = "にコメントがあります"
         makeAttachments data, targetSlackUser, color, word, "comment"

--- a/scripts/pull_request_notification.coffee
+++ b/scripts/pull_request_notification.coffee
@@ -46,7 +46,6 @@ module.exports = (robot) ->
 
   postPullRequestReviewComment = (data) ->
     action = data.action
-    comment = data.review
     pullRequest = data.pull_request
     assignee = pullRequest.assignee
     switch action

--- a/scripts/user_parser.coffee
+++ b/scripts/user_parser.coffee
@@ -1,0 +1,2 @@
+module.exports = parsedUser: (login) ->
+  login.replace /-/g, "_"


### PR DESCRIPTION
## 概要
githubのユーザ名にハイフンがついている場合に対応できるようにした。

環境変数登録の際に、ハイフンは `_`にして登録してもらう(環境変数に `-`は使えない)
環境変数は従来通り小文字のままでいい。(e.g. nttr_kutuzawa)

githubユーザ名からslackユーザ名に変換する際 にすべての`-`を`_`にreplaceする。

それと使われていない変数を削除した